### PR TITLE
Publish glued intermediary under new supported format and Update Mapping-IO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,11 +40,11 @@ def ENV = System.getenv()
 
 def published = false
 def localMappingsPath = "$buildDir/v2Mappings"
-def localv1NewMappingsPath = "$buildDir/v1NewMappings"
-def localv2NewMappingsPath = "$buildDir/v2NewMappings"
+def localv1UpstreamedMappingsPath = "$buildDir/v1UpstreamedMappings"
+def localv2UpstreamedMappingsPath = "$buildDir/v2UpstreamedMappings"
 new File(localMappingsPath).mkdirs()
-new File(localv1NewMappingsPath).mkdirs()
-new File(localv2NewMappingsPath).mkdirs()
+new File(localv1UpstreamedMappingsPath).mkdirs()
+new File(localv2UpstreamedMappingsPath).mkdirs()
 file('mappings').eachFile {
     if (!it.name.endsWith(".tiny")) return
 
@@ -61,8 +61,8 @@ file('mappings').eachFile {
 
     File v1MappingFile = it
     File v2MappingFile = new File("$localMappingsPath/${it.name}")
-    File v1NewMappingFile = new File("$localv1NewMappingsPath/${it.name}")
-    File v2NewMappingFile = new File("$localv2NewMappingsPath/${it.name}")
+    File v1UpstreamedMappingFile = new File("$localv1UpstreamedMappingsPath/${it.name}")
+    File v2UpstreamedMappingFile = new File("$localv2UpstreamedMappingsPath/${it.name}")
 
     def conversionTask = "convert${it.name}ToV2"
     tasks.register(conversionTask) {
@@ -80,28 +80,28 @@ file('mappings').eachFile {
         }
     }
 
-    def newV1Task = "toNewV1"
-    tasks.register(newV1Task) {
-        group = "New V1 Conversion"
+    def V1UpstreamedTask = "toV1Upstreamed"
+    tasks.register(V1UpstreamedTask) {
+        group = "V1 Upstreamed Conversion"
         inputs.file(v1MappingFile)
-        outputs.file(v1NewMappingFile)
+        outputs.file(v1UpstreamedMappingFile)
 
         doLast {
             def memoryMappingTree = new MemoryMappingTree()
             MappingDstNsReorder reorder = new MappingDstNsReorder(memoryMappingTree, "clientOfficial", "serverOfficial")
             MappingNsRenamer renamer = new MappingNsRenamer(reorder, ["client": "clientOfficial", "server": "serverOfficial"])
             MappingReader.read(v1MappingFile.toPath(), renamer)
-            try (MappingWriter mappingWriter = MappingWriter.create(v1NewMappingFile.toPath(), MappingFormat.TINY_FILE)) {
+            try (MappingWriter mappingWriter = MappingWriter.create(v1UpstreamedMappingFile.toPath(), MappingFormat.TINY_FILE)) {
                 memoryMappingTree.accept(mappingWriter)
             }
         }
     }
 
-    def newV2Task = "toNewV2"
-    tasks.register(newV2Task) {
-        group = "New V2 Conversion"
+    def V2UpstreamedTask = "toV2Upstreamed"
+    tasks.register(V2UpstreamedTask) {
+        group = "V2 Upstreamed Conversion"
         inputs.file(v2MappingFile)
-        outputs.file(v2NewMappingFile)
+        outputs.file(v2UpstreamedMappingFile)
         dependsOn(conversionTask)
 
         doLast {
@@ -109,7 +109,7 @@ file('mappings').eachFile {
             MappingDstNsReorder reorder = new MappingDstNsReorder(memoryMappingTree, "clientOfficial", "serverOfficial")
             MappingNsRenamer renamer = new MappingNsRenamer(reorder, ["client": "clientOfficial", "server": "serverOfficial"])
             MappingReader.read(v2MappingFile.toPath(), renamer)
-            try (MappingWriter mappingWriter = MappingWriter.create(v2NewMappingFile.toPath(), MappingFormat.TINY_2_FILE)) {
+            try (MappingWriter mappingWriter = MappingWriter.create(v2UpstreamedMappingFile.toPath(), MappingFormat.TINY_2_FILE)) {
                 memoryMappingTree.accept(mappingWriter)
             }
         }
@@ -117,12 +117,12 @@ file('mappings').eachFile {
 
     Jar makeV1Jar = makeJar(mcVer, v1MappingFile, false, false)
     Jar makeV2Jar = makeJar(mcVer, v2MappingFile, true, false)
-    Jar makeFixedV1Jar = makeJar(mcVer, v1NewMappingFile, false, true)
-    Jar makeFixedV2Jar = makeJar(mcVer, v2NewMappingFile, true, true)
+    Jar makeUpstreamedV1Jar = makeJar(mcVer, v1UpstreamedMappingFile, false, true)
+    Jar makeUpstreamedV2Jar = makeJar(mcVer, v2UpstreamedMappingFile, true, true)
 
     makeV2Jar.dependsOn conversionTask
-    makeFixedV1Jar.dependsOn newV1Task
-    makeFixedV2Jar.dependsOn newV2Task
+    makeUpstreamedV1Jar.dependsOn V1UpstreamedTask
+    makeUpstreamedV2Jar.dependsOn V2UpstreamedTask
 
     publishing {
         publications {
@@ -138,15 +138,15 @@ file('mappings').eachFile {
                     classifier = "v2"
                 }
             }
-            create("${mcVer.replace(" ", "")}Fixed_mavenJava", MavenPublication) {
+            create("${mcVer.replace(" ", "")}Upstreamed_mavenJava", MavenPublication) {
                 groupId "babric"
-                artifactId "intermediary-fixed"
+                artifactId "intermediary-upstreamed"
                 version mcVer
-                artifact(makeFixedV1Jar.archiveFile) {
-                    builtBy makeFixedV1Jar
+                artifact(makeUpstreamedV1Jar.archiveFile) {
+                    builtBy makeUpstreamedV1Jar
                 }
-                artifact(makeFixedV2Jar.archiveFile) {
-                    builtBy makeFixedV2Jar
+                artifact(makeUpstreamedV2Jar.archiveFile) {
+                    builtBy makeUpstreamedV2Jar
                     classifier = "v2"
                 }
             }
@@ -158,9 +158,9 @@ if (!published) {
     throw new RuntimeException("Nothing to publish, override with the FORCE_PUBLISH env")
 }
 
-def makeJar(String mcVersion, File mappings, boolean v2, boolean fixed) {
-    def jarFilename = "intermediary-" + (fixed ? "fixed-" : "") + mcVersion + (v2 ? "-v2" : "")
-    return task("${mcVersion}_makeJar" + (v2 ? "v2" : "") + (fixed ? "Fixed" : ""), type: Jar) {
+def makeJar(String mcVersion, File mappings, boolean v2, boolean upstreamed) {
+    def jarFilename = "intermediary-" + (upstreamed ? "upstreamed-" : "") + mcVersion + (v2 ? "-v2" : "")
+    return task("${mcVersion}_makeJar" + (v2 ? "v2" : "") + (upstreamed ? "Upstreamed" : ""), type: Jar) {
         baseName jarFilename
         from(file(mappings)) {
             into "mappings"

--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,8 @@ def ENV = System.getenv()
 
 def published = false
 def localMappingsPath = "$buildDir/v2Mappings"
-def localv1UpstreamedMappingsPath = "$buildDir/v1UpstreamedMappings"
-def localv2UpstreamedMappingsPath = "$buildDir/v2UpstreamedMappings"
+def localv1UpstreamedMappingsPath = "$buildDir/v1UpstreamMappings"
+def localv2UpstreamedMappingsPath = "$buildDir/v2UpstreamMappings"
 new File(localMappingsPath).mkdirs()
 new File(localv1UpstreamedMappingsPath).mkdirs()
 new File(localv2UpstreamedMappingsPath).mkdirs()
@@ -80,9 +80,9 @@ file('mappings').eachFile {
         }
     }
 
-    def V1UpstreamedTask = "toV1Upstreamed"
+    def V1UpstreamedTask = "toV1Upstream"
     tasks.register(V1UpstreamedTask) {
-        group = "V1 Upstreamed Conversion"
+        group = "V1 Upstream Conversion"
         inputs.file(v1MappingFile)
         outputs.file(v1UpstreamedMappingFile)
 
@@ -97,9 +97,9 @@ file('mappings').eachFile {
         }
     }
 
-    def V2UpstreamedTask = "toV2Upstreamed"
+    def V2UpstreamedTask = "toV2Upstream"
     tasks.register(V2UpstreamedTask) {
-        group = "V2 Upstreamed Conversion"
+        group = "V2 Upstream Conversion"
         inputs.file(v2MappingFile)
         outputs.file(v2UpstreamedMappingFile)
         dependsOn(conversionTask)
@@ -138,9 +138,9 @@ file('mappings').eachFile {
                     classifier = "v2"
                 }
             }
-            create("${mcVer.replace(" ", "")}Upstreamed_mavenJava", MavenPublication) {
+            create("${mcVer.replace(" ", "")}Upstream_mavenJava", MavenPublication) {
                 groupId "babric"
-                artifactId "intermediary-upstreamed"
+                artifactId "intermediary-upstream"
                 version mcVer
                 artifact(makeUpstreamedV1Jar.archiveFile) {
                     builtBy makeUpstreamedV1Jar
@@ -159,8 +159,8 @@ if (!published) {
 }
 
 def makeJar(String mcVersion, File mappings, boolean v2, boolean upstreamed) {
-    def jarFilename = "intermediary-" + (upstreamed ? "upstreamed-" : "") + mcVersion + (v2 ? "-v2" : "")
-    return task("${mcVersion}_makeJar" + (v2 ? "v2" : "") + (upstreamed ? "Upstreamed" : ""), type: Jar) {
+    def jarFilename = "intermediary-" + (upstreamed ? "upstream-" : "") + mcVersion + (v2 ? "-v2" : "")
+    return task("${mcVersion}_makeJar" + (v2 ? "v2" : "") + (upstreamed ? "Upstream" : ""), type: Jar) {
         baseName jarFilename
         from(file(mappings)) {
             into "mappings"

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 import net.fabricmc.mappingio.*
-import net.fabricmc.mappingio.adapter.MappingNsCompleter
+import net.fabricmc.mappingio.adapter.*
 import net.fabricmc.mappingio.format.*
 import net.fabricmc.mappingio.tree.*
 
@@ -12,7 +12,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'net.fabricmc:mapping-io:0.3.0'
+        classpath 'net.fabricmc:mapping-io:0.6.1'
     }
 }
 
@@ -40,7 +40,11 @@ def ENV = System.getenv()
 
 def published = false
 def localMappingsPath = "$buildDir/v2Mappings"
+def localv1NewMappingsPath = "$buildDir/v1NewMappings"
+def localv2NewMappingsPath = "$buildDir/v2NewMappings"
 new File(localMappingsPath).mkdirs()
+new File(localv1NewMappingsPath).mkdirs()
+new File(localv2NewMappingsPath).mkdirs()
 file('mappings').eachFile {
     if (!it.name.endsWith(".tiny")) return
 
@@ -57,6 +61,8 @@ file('mappings').eachFile {
 
     File v1MappingFile = it
     File v2MappingFile = new File("$localMappingsPath/${it.name}")
+    File v1NewMappingFile = new File("$localv1NewMappingsPath/${it.name}")
+    File v2NewMappingFile = new File("$localv2NewMappingsPath/${it.name}")
 
     def conversionTask = "convert${it.name}ToV2"
     tasks.register(conversionTask) {
@@ -68,16 +74,55 @@ file('mappings').eachFile {
             def memoryMappingTree = new MemoryMappingTree()
             MappingNsCompleter nsCompleter = new MappingNsCompleter(memoryMappingTree, Map.of("glue", "intermediary", "server", "intermediary", "client", "intermediary"));
             MappingReader.read(v1MappingFile.toPath(), nsCompleter)
-            try (MappingWriter mappingWriter = MappingWriter.create(v2MappingFile.toPath(), MappingFormat.TINY_2)) {
+            try (MappingWriter mappingWriter = MappingWriter.create(v2MappingFile.toPath(), MappingFormat.TINY_2_FILE)) {
                 memoryMappingTree.accept(mappingWriter)
             }
         }
     }
 
-    Jar makeV1Jar = makeJar(mcVer, v1MappingFile, false)
-    Jar makeV2Jar = makeJar(mcVer, v2MappingFile, true)
+    def newV1Task = "toNewV1"
+    tasks.register(newV1Task) {
+        group = "New V1 Conversion"
+        inputs.file(v1MappingFile)
+        outputs.file(v1NewMappingFile)
+
+        doLast {
+            def memoryMappingTree = new MemoryMappingTree()
+            MappingDstNsReorder reorder = new MappingDstNsReorder(memoryMappingTree, "clientOfficial", "serverOfficial")
+            MappingNsRenamer renamer = new MappingNsRenamer(reorder, ["client": "clientOfficial", "server": "serverOfficial"])
+            MappingReader.read(v1MappingFile.toPath(), renamer)
+            try (MappingWriter mappingWriter = MappingWriter.create(v1NewMappingFile.toPath(), MappingFormat.TINY_FILE)) {
+                memoryMappingTree.accept(mappingWriter)
+            }
+        }
+    }
+
+    def newV2Task = "toNewV2"
+    tasks.register(newV2Task) {
+        group = "New V2 Conversion"
+        inputs.file(v2MappingFile)
+        outputs.file(v2NewMappingFile)
+        dependsOn(conversionTask)
+
+        doLast {
+            def memoryMappingTree = new MemoryMappingTree()
+            MappingDstNsReorder reorder = new MappingDstNsReorder(memoryMappingTree, "clientOfficial", "serverOfficial")
+            MappingNsRenamer renamer = new MappingNsRenamer(reorder, ["client": "clientOfficial", "server": "serverOfficial"])
+            MappingReader.read(v2MappingFile.toPath(), renamer)
+            try (MappingWriter mappingWriter = MappingWriter.create(v2NewMappingFile.toPath(), MappingFormat.TINY_2_FILE)) {
+                memoryMappingTree.accept(mappingWriter)
+            }
+        }
+    }
+
+    Jar makeV1Jar = makeJar(mcVer, v1MappingFile, false, false)
+    Jar makeV2Jar = makeJar(mcVer, v2MappingFile, true, false)
+    Jar makeFixedV1Jar = makeJar(mcVer, v1NewMappingFile, false, true)
+    Jar makeFixedV2Jar = makeJar(mcVer, v2NewMappingFile, true, true)
 
     makeV2Jar.dependsOn conversionTask
+    makeFixedV1Jar.dependsOn newV1Task
+    makeFixedV2Jar.dependsOn newV2Task
 
     publishing {
         publications {
@@ -93,6 +138,18 @@ file('mappings').eachFile {
                     classifier = "v2"
                 }
             }
+            create("${mcVer.replace(" ", "")}Fixed_mavenJava", MavenPublication) {
+                groupId "babric"
+                artifactId "intermediary-fixed"
+                version mcVer
+                artifact(makeFixedV1Jar.archiveFile) {
+                    builtBy makeFixedV1Jar
+                }
+                artifact(makeFixedV2Jar.archiveFile) {
+                    builtBy makeFixedV2Jar
+                    classifier = "v2"
+                }
+            }
         }
     }
 }
@@ -101,9 +158,9 @@ if (!published) {
     throw new RuntimeException("Nothing to publish, override with the FORCE_PUBLISH env")
 }
 
-def makeJar(String mcVersion, File mappings, boolean v2) {
-    def jarFilename = "intermediary-" + mcVersion + (v2 ? "-v2" : "")
-    return task("${mcVersion}_makeJar" + (v2 ? "v2" : ""), type: Jar) {
+def makeJar(String mcVersion, File mappings, boolean v2, boolean fixed) {
+    def jarFilename = "intermediary-" + (fixed ? "fixed-" : "") + mcVersion + (v2 ? "-v2" : "")
+    return task("${mcVersion}_makeJar" + (v2 ? "v2" : "") + (fixed ? "Fixed" : ""), type: Jar) {
         baseName jarFilename
         from(file(mappings)) {
             into "mappings"


### PR DESCRIPTION
Upstream fabric loader support "glued" intermediary since `0.16.0` under a slightly different format.
The only change is the namespaces names and order.
Those "fixed" intermediaries will be published to `babric:intermediary-upstream:${mcversion}`.